### PR TITLE
Redid website and service status badges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@
 
 ### 📃 Table Of Contents 
 
-- [AI](#-ai)
+- [Artificial Intelligence](#-artificial-intelligence)
 - [Browsers](#-browsers)
 - [CI](#-ci)
+- [Cloud Storage](#-cloud-storage)
 - [Cloud Systems](#-cloud-systems)
 - [Collaboration Tools](#-collaboration-tools)
 - [Cryptocurrencies](#-cryptocurrencies)
@@ -82,7 +83,7 @@
 >
 > Alternateively, use the Table Of Contents above to look for your badge.
 
-### 🤖 AI:
+### 🤖 Artificial Intelligence:
 | Preview | Markdown Code |
 |---------|---------------|
 | [![Amazon Alexa](https://img.shields.io/badge/Amazon%20Alexa-00CAFF?logo=amazonalexa&logoColor=fff)](#) | `[![Amazon Alexa](https://img.shields.io/badge/Amazon%20Alexa-00CAFF?logo=amazonalexa&logoColor=fff)](#)` |
@@ -131,6 +132,24 @@
 | [![Jenkins](https://img.shields.io/badge/Jenkins-D24939?logo=jenkins&logoColor=white)](#) | `[![Jenkins](https://img.shields.io/badge/Jenkins-D24939?logo=jenkins&logoColor=white)](#)` |
 | [![Semaphore](https://img.shields.io/badge/Semaphore-19A974?logo=semaphoreci&logoColor=fff)](#) | `[![Semaphore](https://img.shields.io/badge/Semaphore-19A974?logo=semaphoreci&logoColor=fff)](#)` |
 | [![Travis CI](https://img.shields.io/badge/Travis%20CI-3EAAAF?logo=travisci&logoColor=fff)](#) | `[![Travis CI](https://img.shields.io/badge/Travis%20CI-3EAAAF?logo=travisci&logoColor=fff)](#)` |
+
+<div align="center">
+
+[⬆️ Return back to top ⬆️](#-table-of-contents)
+
+</div>
+
+### 🌫️ Cloud Storage:
+| Preview | Markdown Code |
+|---------|---------------|
+| [![Box](https://img.shields.io/badge/Box-0061D5?logo=box&logoColor=fff)](#) | `[![Box](https://img.shields.io/badge/Box-0061D5?logo=box&logoColor=fff)](#)` |
+| [![Dropbox](https://img.shields.io/badge/Dropbox-0061FF?logo=dropbox&logoColor=fff)](#) | `[![Dropbox](https://img.shields.io/badge/Dropbox-0061FF?logo=dropbox&logoColor=fff)](#)` |
+| [![Google Drive](https://img.shields.io/badge/Google%20Drive-4285F4?logo=googledrive&logoColor=fff)](#) | `[![Google Drive](https://img.shields.io/badge/Google%20Drive-4285F4?logo=googledrive&logoColor=fff)](#)` |
+| [![Mega](https://img.shields.io/badge/Mega-%23D90007.svg?logo=mega&logoColor=white)](#) | `[![Mega](https://img.shields.io/badge/Mega-%23D90007.svg?logo=mega&logoColor=white)](#)` |
+| [![Microsoft OneDrive](https://img.shields.io/badge/Microsoft%20OneDrive-0078D4?logo=microsoftonedrive&logoColor=fff)](#) | `[![Microsoft OneDrive](https://img.shields.io/badge/Microsoft%20OneDrive-0078D4?logo=microsoftonedrive&logoColor=fff)](#)` |
+| [![Proton Drive](https://img.shields.io/badge/Proton%20Drive-6d4aff?logo=proton%20drive&logoColor=white)](#) | `[![Proton Drive](https://img.shields.io/badge/Proton%20Drive-6d4aff?logo=proton%20drive&logoColor=white)](#)` |
+
+
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [CI](#-ci)
 - [Cloud Storage](#-cloud-storage)
 - [Cloud Systems](#-cloud-systems)
+- [Code Coverage](#-code-coverage)
 - [Collaboration Tools](#-collaboration-tools)
 - [Cryptocurrencies](#-cryptocurrencies)
 - [Databases](#-databases)
@@ -76,7 +77,7 @@
 - [Version Control](#-version-control)
 - [Virtual Reality](#-virtual-reality)
 - [Web Technologies](#-web-technologies)
-- [Website and Service Status](#-website-and-service-status)
+- [Website Status](#-website-status)
 
 > [!TIP]
 > Use `Ctrl + F` to find a the badge you are looking for quickly.
@@ -266,6 +267,27 @@
 | [![Inkscape](https://img.shields.io/badge/Inkscape-000000?logo=Inkscape&logoColor=white)](#) | `[![Inkscape](https://img.shields.io/badge/Inkscape-000000?logo=Inkscape&logoColor=white)](#)` |
 | [![Krita](https://img.shields.io/badge/Krita-203759?logo=krita&logoColor=EEF37B)](#) | `[![Krita](https://img.shields.io/badge/Krita-203759?logo=krita&logoColor=EEF37B)](#)` |
 | [![Unsplash](https://img.shields.io/badge/Unsplash-000000?logo=Unsplash&logoColor=white)](#) | `[![Unsplash](https://img.shields.io/badge/Unsplash-000000?logo=Unsplash&logoColor=white)](#)` |
+
+<div align="center">
+
+[⬆️ Return back to top ⬆️](#-table-of-contents)
+
+</div>
+
+### 🌋 Code Coverage:  
+
+| Preview | Markdown Code |
+|---------|---------------|
+| [![Codecov](https://img.shields.io/badge/Codecov-F01F7A?logo=codecov&logoColor=fff)](#) | `[![Codecov](https://img.shields.io/badge/Codecov-F01F7A?logo=codecov&logoColor=fff)](#)` |
+| [![Code Climate](https://img.shields.io/badge/Code%20Climate-000?logo=codeclimate&logoColor=fff)](#) | `[![Code Climate](https://img.shields.io/badge/Code%20Climate-000?logo=codeclimate&logoColor=fff)](#) ` |
+| [![Codacy](https://img.shields.io/badge/Codacy-222F29?logo=codacy&logoColor=fff)](#) | `![Codacy](https://img.shields.io/badge/Codacy-222F29?logo=codacy&logoColor=fff)](#)` |
+| [![Coveralls](https://img.shields.io/badge/Coveralls-3F5767?logo=coveralls&logoColor=fff)](#) | `[![Coveralls](https://img.shields.io/badge/Coveralls-3F5767?logo=coveralls&logoColor=fff)](#)` |
+| [![SonarCloud](https://img.shields.io/badge/SonarCloud-F3702A?logo=sonarcloud&logoColor=fff)](#) | `[![SonarCloud](https://img.shields.io/badge/SonarCloud-F3702A?logo=sonarcloud&logoColor=fff)](#)` |
+| [![Snyk](https://img.shields.io/badge/Snyk-4C4A73?logo=snyk&logoColor=fff)](#) | `[![Snyk](https://img.shields.io/badge/Snyk-4C4A73?logo=snyk&logoColor=fff)](#)` |
+
+
+
+
 
 <div align="center">
 
@@ -748,25 +770,12 @@
 
 </div>
 
-### 🍏 Website and Service Status:
+### 🍏 Website Status:
 | Preview | Markdown Code |
 |---------|---------------|
-| [![Azure DevOps](https://img.shields.io/badge/Azure%20DevOps-blue?logo=azure-devops&logoColor=white)](#) | `[![Azure DevOps](https://img.shields.io/badge/Azure%20DevOps-blue?logo=azure-devops&logoColor=white)](#)` |
-| [![Codecov](https://img.shields.io/badge/Codecov-blue?logo=codecov&logoColor=white)](#) | `[![Codecov](https://img.shields.io/badge/Codecov-blue?logo=codecov&logoColor=white)](#)` |
-| [![Code Climate](https://img.shields.io/badge/Code%20Climate-orange?logo=code-climate&logoColor=white)](#) | `[![Code Climate](https://img.shields.io/badge/Code%20Climate-orange?logo=code-climate&logoColor=white)](#)` |
-| [![Codacy](https://img.shields.io/badge/Codacy-blue?logo=codacy&logoColor=white)](#) | `[![Codacy](https://img.shields.io/badge/Codacy-blue?logo=codacy&logoColor=white)](#)` |
-| [![Coveralls](https://img.shields.io/badge/Coveralls-green?logo=coveralls&logoColor=white)](#) | `[![Coveralls](https://img.shields.io/badge/Coveralls-green?logo=coveralls&logoColor=white)](#)` |
-| [![Coverity Scan](https://img.shields.io/coverity/scan/12892)](#) | `[![Coverity Scan](https://img.shields.io/coverity/scan/12892)](#)` |
-| [![Docker Pulls](https://img.shields.io/docker/pulls/library/alpine.svg)](https://hub.docker.com/_/alpine) | `[![Docker Pulls](https://img.shields.io/docker/pulls/library/alpine.svg)](https://hub.docker.com/_/alpine)` |
-| [![Downloads](https://img.shields.io/pypi/dm/Django.svg)](https://pypi.org/project/Django/) | `[![Downloads](https://img.shields.io/pypi/dm/Django.svg)](https://pypi.org/project/Django/)` |
-| [![Heroku](https://img.shields.io/badge/Heroku-%23430098.svg?logo=heroku&logoColor=white)](#) | `[![Heroku](https://img.shields.io/badge/Heroku-%23430098.svg?logo=heroku&logoColor=white)](#)` |
-| [![Netlify](https://img.shields.io/badge/Netlify-%23000000.svg?&logo=netlify&logoColor=#00C7B7)](#) | `[![Netlify](https://img.shields.io/badge/Netlify-blue?logo=netlify&logoColor=white)](#)` |
-| [![npm](https://img.shields.io/npm/v/npm.svg)](https://www.npmjs.com/package/npm) | `[![npm](https://img.shields.io/npm/v/npm.svg)](https://www.npmjs.com/package/npm)` |
-| [![Python versions](https://img.shields.io/pypi/pyversions/Django.svg)](https://pypi.org/project/Django/) | `[![Python versions](https://img.shields.io/pypi/pyversions/Django.svg)](https://pypi.org/project/Django/)` |
-| [![SonarCloud](https://img.shields.io/badge/SonarCloud-blue?logo=sonarcloud&logoColor=white)](#) | `[![SonarCloud](https://img.shields.io/badge/SonarCloud-blue?logo=sonarcloud&logoColor=white)](#)` |
-| [![Snyk](https://img.shields.io/badge/Snyk-purple?logo=snyk&logoColor=white)](#) | `[![Snyk](https://img.shields.io/badge/Snyk-purple?logo=snyk&logoColor=white)](#)` |
-| [![Travis CI](https://img.shields.io/travis/com/badges/shields/main)](#) | `[![Travis CI](https://img.shields.io/travis/com/badges/shields/main)](#)` |
 | [![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](https://shields.io/) | `[![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](https://shields.io/)` |
+| [![Website](https://img.shields.io/website-up-down-green-red/http/NOTAWORKINGLINK.com.svg)](#) | `[![Website](https://img.shields.io/website-up-down-green-red/http/NOTAWORKINGLINK.com.svg)](#)` |
+
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 
 ### 📃 Table Of Contents 
 
+- [AI](#-ai)
 - [Browsers](#-browsers)
 - [CI](#-ci)
 - [Cloud Systems](#-cloud-systems)
@@ -80,6 +81,23 @@
 > Use `Ctrl + F` to find a the badge you are looking for quickly.
 >
 > Alternateively, use the Table Of Contents above to look for your badge.
+
+### 🤖 AI:
+| Preview | Markdown Code |
+|---------|---------------|
+| [![Amazon Alexa](https://img.shields.io/badge/Amazon%20Alexa-00CAFF?logo=amazonalexa&logoColor=fff)](#) | `[![Amazon Alexa](https://img.shields.io/badge/Amazon%20Alexa-00CAFF?logo=amazonalexa&logoColor=fff)](#)` |
+| [![ChatGPT](https://img.shields.io/badge/ChatGPT-74aa9c?logo=openai&logoColor=white)](#) | `[![ChatGPT](https://img.shields.io/badge/ChatGPT-74aa9c?logo=openai&logoColor=white)](#)` |
+| [![Dependabot](https://img.shields.io/badge/Dependabot-025E8C?logo=dependabot&logoColor=fff)](#) | `[![Dependabot](https://img.shields.io/badge/Dependabot-025E8C?logo=dependabot&logoColor=fff)](#)` |
+| [![Google Assistant](https://img.shields.io/badge/Google%20Assistant-4285F4?logo=googleassistant&logoColor=fff)](#) | `[![Google Assistant](https://img.shields.io/badge/Google%20Assistant-4285F4?logo=googleassistant&logoColor=fff)](#)` |
+| [![Google Bard](https://img.shields.io/badge/Google%20Bard-886FBF?logo=googlebard&logoColor=fff)](#) | `[![Google Bard](https://img.shields.io/badge/Google%20Bard-886FBF?logo=googlebard&logoColor=fff)](#)` |
+
+<!-- Bard is Google's new AI tool, competing with ChatGPT. Learn more at https://bard.google.com. !-->
+
+<div align="center">
+
+[⬆️ Return back to top ⬆️](#-table-of-contents)
+
+</div>
 
 ### 🌐 Browsers:
 | Preview | Markdown Code |


### PR DESCRIPTION
---------
- 📄 Seperated the code coverage badges and the website status badges from that category to their own respective ones
- 🔥 Removed "Netlify" and "Heroku" as they are hosting platforms and there isn't currently a section for hosting yet (coming soon though!)

- ⚠️ Removed many badges relating to repository status ⚠️